### PR TITLE
Enable wartremover.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -249,6 +249,10 @@ lazy val settings =
   resolverSettings ++
   scalafmtSettings
 
+// The following warts will not be checked.
+// TODO: Try to check for all warts.
+val disabledWarts = Seq(Wart.Any, Wart.DefaultArguments)
+
 lazy val commonSettings =
   Seq(
     headerLicense := Some(HeaderLicense.AGPLv3(s"2014 - $currentYear", "Contributors as noted in the AUTHORS.md file")),
@@ -261,7 +265,7 @@ lazy val commonSettings =
       "-feature",
       "-target:jvm-1.8",
       "-unchecked",
-      "-Xfatal-warnings",
+      //"-Xfatal-warnings",
       "-Xfuture",
       "-Xlint",
       "-Ydelambdafy:method",
@@ -276,7 +280,7 @@ lazy val commonSettings =
       "-source", "1.8",
       "-target", "1.8"
     ),
-    //wartremoverWarnings in (Compile, compile) ++= Warts.unsafe
+    wartremoverWarnings in (Compile, compile) ++= Warts.unsafe.filterNot(w => disabledWarts.contains(w))
   )
 
 lazy val resolverSettings =

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/CastStringToLong.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/CastStringToLong.scala
@@ -27,7 +27,7 @@ import com.wegtam.tensei.agent.transformers.BaseTransformer.{
 import scala.language.existentials
 
 object CastStringToLong {
-  def props: Props = Props(classOf[CastStringToLong])
+  def props: Props = Props(new CastStringToLong())
 }
 
 /**

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/Concat.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/Concat.scala
@@ -25,7 +25,7 @@ import akka.actor.Props
 import akka.util.ByteString
 
 object Concat {
-  def props: Props = Props(classOf[Concat])
+  def props: Props = Props(new Concat())
 }
 
 /**
@@ -40,22 +40,10 @@ class Concat extends BaseTransformer {
   override def transform: Receive = {
     case msg: StartTransformation =>
       log.debug("Starting concatenation of sources: {}", msg.src)
-      val params = msg.options.params
-      val separator =
-        if (params.exists(p => p._1 == "separator"))
-          params.find(p => p._1 == "separator").get._2.asInstanceOf[String]
-        else
-          ""
-      val prefix =
-        if (params.exists(p => p._1 == "prefix"))
-          params.find(p => p._1 == "prefix").get._2.asInstanceOf[String]
-        else
-          ""
-      val suffix =
-        if (params.exists(p => p._1 == "suffix"))
-          params.find(p => p._1 == "suffix").get._2.asInstanceOf[String]
-        else
-          ""
+      val params    = msg.options.params
+      val separator = paramValue("separator")(params)
+      val prefix    = paramValue("prefix")(params)
+      val suffix    = paramValue("suffix")(params)
 
       val strings = msg.src.map {
         case bs: ByteString => bs.utf8String

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/DateConverter.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/DateConverter.scala
@@ -100,16 +100,13 @@ class DateConverter extends BaseTransformer {
 
       val params = msg.options.params
 
-      val timezone = Try(params.find(p => p._1 == "timezone") match {
-        case Some((_, t)) => ZoneId.of(t)
-        case None         => ZoneId.of("UTC")
-      }) match {
+      val timezone = Try(paramValueO("timezone")(params).map(ZoneId.of).getOrElse(ZoneId.of("UTC"))) match {
         case scala.util.Failure(f) =>
           log.error(f, "Could not parse given timezone!")
           ZoneId.of("UTC")
         case scala.util.Success(z) => z
       }
-      val format        = params.find(p => p._1 == "format").fold("yyyy-MM-dd HH:mm:ss")(_._2.trim)
+      val format        = paramValueO("format")(params).fold("yyyy-MM-dd HH:mm:ss")(_.trim)
       val dateFormatter = DateTimeFormatter.ofPattern(format)
       val result        = msg.src.map(DateConverter.convertDate(dateFormatter)(timezone))
 

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/DateTypeConverter.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/DateTypeConverter.scala
@@ -26,7 +26,7 @@ import com.wegtam.tensei.agent.transformers.BaseTransformer.{
 }
 
 object DateTypeConverter {
-  def props: Props = Props(classOf[DateTypeConverter])
+  def props: Props = Props(new DateTypeConverter())
 }
 
 /**
@@ -45,14 +45,11 @@ class DateTypeConverter extends BaseTransformer with DateTypeConverterFunctions 
     case msg: StartTransformation =>
       log.debug("Start DateTypeConverter")
       val params = msg.options.params
+      val tp     = paramValue("target")(params).trim
       val targetType =
-        if (params.exists(p => p._1 == "target")) {
-          val t = params.find(p => p._1 == "target").get._2.trim
-          if (t.nonEmpty)
-            t
-          else
-            DEFAULT_TARGET_TYPE
-        } else
+        if (tp.nonEmpty)
+          tp
+        else
           DEFAULT_TARGET_TYPE
 
       val result =

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/DateValueToString.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/DateValueToString.scala
@@ -46,15 +46,7 @@ class DateValueToString extends BaseTransformer {
     case msg: StartTransformation =>
       log.debug("Start DateValueToString")
       val params = msg.options.params
-      val format =
-        if (params.exists(p => p._1 == "format")) {
-          val t = params.find(p => p._1 == "format").get._2.trim
-          if (t.nonEmpty)
-            t
-          else
-            ""
-        } else
-          ""
+      val format = paramValue("format")(params).trim
 
       val result: List[ByteString] =
         if (format.isEmpty)

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/DrupalVanCodeTransformer.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/DrupalVanCodeTransformer.scala
@@ -34,7 +34,7 @@ import com.wegtam.tensei.agent.transformers.BaseTransformer.{
 object DrupalVanCodeTransformer {
   val name = "DrupalVanCodeTransformer"
 
-  def props: Props = Props(classOf[DrupalVanCodeTransformer])
+  def props: Props = Props(new DrupalVanCodeTransformer())
 }
 
 /**

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/IDTransformer.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/IDTransformer.scala
@@ -48,33 +48,22 @@ class IDTransformer extends BaseTransformer {
 
   override def transform: Receive = {
     case msg: GeneratorResponse => //Nachricht vom Generator
-      s.get ! TransformerResponse(msg.data, classOf[String])
+      s.foreach(_ ! TransformerResponse(msg.data, classOf[String]))
 
     case msg: StartTransformation => //Nachricht vom Prozessor
       s = Option(sender())
 
       val params = msg.options.params
 
-      val idtype =
-        if (params.exists(p => p._1 == "type"))
-          params.find(p => p._1 == "type").get._2.asInstanceOf[String]
-        else
-          "long"
+      val idtype = paramValueO("type")(params).getOrElse("long")
 
-      val field =
-        if (params.exists(p => p._1 == "field"))
-          params.find(p => p._1 == "field").get._2.asInstanceOf[String]
-        else
-          "unnamed"
+      val field = paramValueO("field")(params).getOrElse("unnamed")
 
+      val stp = paramValue("start")(params)
       val start =
-        if (params.exists(p => p._1 == "start")) {
-          val value = params.find(p => p._1 == "start").get._2
-          if (value.nonEmpty)
-            value
-          else
-            "0"
-        } else
+        if (stp.nonEmpty)
+          stp
+        else
           "0"
 
       val actor =

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/LowerOrUpper.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/LowerOrUpper.scala
@@ -47,9 +47,8 @@ class LowerOrUpper extends BaseTransformer {
 
       val params = msg.options.params
 
-      val locale = params.find(p => p._1 == "locale").fold(Locale.getDefault) { p =>
-        val (_, loc) = p
-        val l        = Locale.forLanguageTag(loc)
+      val locale = paramValueO("locale")(params).fold(Locale.getDefault) { loc =>
+        val l = Locale.forLanguageTag(loc)
         if (Locale.getAvailableLocales.contains(l))
           l
         else
@@ -70,11 +69,11 @@ class LowerOrUpper extends BaseTransformer {
 
       val response: TransformerResponse =
         if (msg.src.nonEmpty) {
-          params.find(p => p._1 == "perform").fold(TransformerResponse(msg.src, classOf[String])) {
-            perform =>
+          paramValueO("perform")(params).fold(TransformerResponse(msg.src, classOf[String])) {
+            mode =>
               val res = msg.src.map {
-                case bs: ByteString => performOp(perform._2)(bs.utf8String)
-                case st: String     => performOp(perform._2)(st)
+                case bs: ByteString => performOp(mode)(bs.utf8String)
+                case st: String     => performOp(mode)(st)
                 case otherData      => otherData
               }
               TransformerResponse(res, classOf[String])

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/MergeAndExtractByRegEx.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/MergeAndExtractByRegEx.scala
@@ -46,36 +46,12 @@ class MergeAndExtractByRegEx extends BaseTransformer {
       log.debug("Starting regexp match of the data!")
 
       val params = msg.options.params
-      val regexp =
-        if (params.exists(p => p._1 == "regexp"))
-          params.find(p => p._1 == "regexp").get._2.asInstanceOf[String]
-        else
-          ""
-      val filler: String =
-        if (params.exists(p => p._1 == "filler") && params
-              .find(p => p._1 == "filler")
-              .get
-              ._2
-              .nonEmpty)
-          params.find(p => p._1 == "filler").get._2.asInstanceOf[String]
-        else
-          ""
-      val groups: List[Int] =
-        if (params.exists(p => p._1 == "groups") && params
-              .find(p => p._1 == "groups")
-              .get
-              ._2
-              .nonEmpty)
-          params
-            .find(p => p._1 == "groups")
-            .get
-            ._2
-            .asInstanceOf[String]
-            .split(",")
-            .map(_.trim.toInt)
-            .toList
-        else
-          List.empty
+      val regexp = paramValue("regexp")(params)
+      val filler = paramValue("filler")(params)
+      val groups = paramValue("groups")(params) match {
+        case "" => List.empty
+        case gs => gs.split(",").toList.map(_.trim.toInt)
+      }
 
       val p: Regex = s"""$regexp""".r
       val matchedParts: List[ByteString] = msg.src.flatMap { e =>

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/Overwrite.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/Overwrite.scala
@@ -67,9 +67,8 @@ class Overwrite extends BaseTransformer {
       val response: Option[TransformerResponse] =
         if (msg.src.nonEmpty) {
           val replaceWith: Option[(Any, Class[_])] =
-            params.find(p => p._1 == "type").fold(None: Option[(Any, Class[_])]) { typeDesc =>
-              val (_, t)     = typeDesc
-              val (_, value) = params.find(p => p._1 == "value").getOrElse(("", ""))
+            paramValueO("type")(params).fold(None: Option[(Any, Class[_])]) { t =>
+              val value = paramValue("value")(params)
               t.toLowerCase(Locale.ROOT) match {
                 case "bigdecimal" =>
                   val v = value match {

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/TimestampCalibrate.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/TimestampCalibrate.scala
@@ -27,7 +27,7 @@ import com.wegtam.tensei.agent.transformers.BaseTransformer.{
 import scalaz._
 
 object TimestampCalibrate {
-  def props: Props = Props(classOf[TimestampCalibrate])
+  def props: Props = Props(new TimestampCalibrate())
 }
 
 /**
@@ -36,8 +36,6 @@ object TimestampCalibrate {
   *
   * Available parameters:
   * `perform` : Add or reduce the value. Values: 'add' -> x*1000 (default), 'reduce' -> x:1000
-  *
-  *
   */
 class TimestampCalibrate extends BaseTransformer {
   override def transform: Receive = {
@@ -46,11 +44,7 @@ class TimestampCalibrate extends BaseTransformer {
 
       val params = msg.options.params
 
-      val perform: String =
-        if (params.exists(p => p._1 == "perform"))
-          params.find(p => p._1 == "perform").get._2.asInstanceOf[String]
-        else
-          ""
+      val perform = paramValue("perform")(params)
 
       val results = msg.src.map { e =>
         \/.fromTryCatch {

--- a/src/main/scala/com/wegtam/tensei/agent/transformers/atomic/TimestampAdjuster.scala
+++ b/src/main/scala/com/wegtam/tensei/agent/transformers/atomic/TimestampAdjuster.scala
@@ -46,11 +46,7 @@ class TimestampAdjuster extends BaseTransformer {
     case msg: StartTransformation =>
       val params = msg.options.params
 
-      val perform: String =
-        if (params.exists(p => p._1 == "perform"))
-          params.find(p => p._1 == "perform").get._2.asInstanceOf[String]
-        else
-          ""
+      val perform = paramValue("perform")(params)
 
       def adjustTimestamp(t: Long): Long =
         perform match {


### PR DESCRIPTION
This is the first step to incremental code cleanup. For this `Xfatal-warnings` had to be disabled. But the goal is to reduce the wartremover warnings with time.

### Changes

* enable wartremover
* customise checked warts
* disable `Xfatal-warnings`
* fix several warnings